### PR TITLE
Fix #5 - added child rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@
 
 ## 0.1.6
 * Fix #4 - add minimatch regex engine
+
+## 0.1.9
+* Fix #5 - add "child" rules

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Just edit ~/.atom/color-tabs-regex.cson (you can open it by "Color Tabs Regex: E
 
 `
 "regex": "#color"
+"prefix":
+  "regex": "#anothercolor"
 `
+
+When using prefixes, the prefix and the regex are concatenated (e.g. if the prefix is `"foo/"` and the regex is `"bar"`, it will check for matches with `"foo/bar"`)
 
 ## Settings
 

--- a/lib/color-tabs-regex.coffee
+++ b/lib/color-tabs-regex.coffee
@@ -59,16 +59,27 @@ module.exports = ColorTabsRegex =
   consumeChangeColor: (changeColor) ->
     processPath = changeColor
 
+  expandRules: (rules, prefix, output) ->
+    output = output || []
+    prefix = prefix || ""
+    for rule of rules
+      if typeof rules[rule] is "string"
+        output[prefix + rule] = rules[rule]
+      else
+        output = @expandRules(rules[rule], rule, output)
+    output
+
   processAllTabs: () ->
     breaks = atom.config.get "color-tabs-regex.breakAfterFirstMatch"
     matcher = atom.config.get "color-tabs-regex.regexEngine"
     colored = []
     CSON.readFile colorFile, (err, content) =>
       unless err
-        count = Object.keys(content).length
+        rules = @expandRules content
+        count = Object.keys(rules).length
         if Object.keys(colors).length != count
           console.log "[color-tabs-regex] defined rules: #{count}"
-        colors = content
+        colors = rules
         paneItems = atom.workspace.getPaneItems()
         for paneItem in paneItems
           if paneItem.getPath?


### PR DESCRIPTION
@averrin ~ Please test this PR, because I haven't. (except basic tests like testing the expandRules function and compiling the coffeescript)

The config CSON might now look like: (in this example I'm using String.match and break on first match)

``` CSON
".*?/Projects/ColorfulProject/":
  "models/":
    ".*?\\.js": "green"
    ".*?\\.sql": "blue"
  ".*?\\.js": "red"
  ".*?\\.html": "blue"
".*?/Projects/GrayProject/.*": "gray"
```

These will be converted to normal rules like this:

``` CSON
".*?/Projects/ColorfulProject/models/.*?\\.js": "green"
".*?/Projects/ColorfulProject/models/.*?\\.sql": "blue"
".*?/Projects/ColorfulProject/.*?\\.js": "red"
".*?/Projects/ColorfulProject/.*?\\.html": "blue"
".*?/Projects/GrayProject/.*": "gray"
```
