### PR TITLE
Fix "Break After First Match" when the same file is open multiple times

### DIFF
--- a/lib/color-tabs-regex.coffee
+++ b/lib/color-tabs-regex.coffee
@@ -74,7 +74,6 @@ module.exports = ColorTabsRegex =
     breaks = atom.config.get "color-tabs-regex.breakAfterFirstMatch"
     matcher = atom.config.get "color-tabs-regex.regexEngine"
     processRules = @expandRules.bind(this)
-    colored = []
     CSON.readFile colorFile, (err, content) =>
       unless err
         rules = processRules content
@@ -92,13 +91,9 @@ module.exports = ColorTabsRegex =
                 try
                   if matchers[matcher] path, re
                     color = colors[re]
-                    if breaks
-                      if colored.indexOf(path) == -1
-                        colored.push path
-                      else
-                        continue
                     console.log "[color-tabs-regex] #{path} -> #{color} matched by '#{re}'"
                     processPath path, color, false
+                    break if breaks
 
                 catch error
                   console.error "[color-tabs-regex] #{error}"


### PR DESCRIPTION
"Break After First Match" broke tab coloring when the same file was open in multiple tabs. When a tab was colored with a regex rule, the file's path was saved to a list, so that a later color rule wouldn't override it.

However, saving the path doesn't really work, because the same path can be open in multiple tabs, which would break coloring for all tabs with that file path. The current code just breaks out of the loop after a color rule match, which seems to work, unless I'm missing an edge case.

Fixes https://github.com/averrin/color-tabs-regex/issues/16 (already closed, but not fixed for all cases).
